### PR TITLE
allow timeout overriding from query context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-link-timeout",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Abort requests that take longer than a specified timeout period",
   "dependencies": {
     "apollo-link": "^1.2.2"

--- a/src/timeoutLink.ts
+++ b/src/timeoutLink.ts
@@ -16,9 +16,10 @@ export default class TimeoutLink extends ApolloLink {
 
   public request(operation: Operation, forward: NextLink) {
     let controller: AbortController;
-    
+    let ctxTimeout: number;
+
     // override timeout from query context
-    var ctxTimeout = operation.getContext().timeout || null;
+    ctxTimeout = operation.getContext().timeout || null;
     if(ctxTimeout <= 0) {
       ctxTimeout = null;
     }

--- a/src/timeoutLink.ts
+++ b/src/timeoutLink.ts
@@ -16,6 +16,12 @@ export default class TimeoutLink extends ApolloLink {
 
   public request(operation: Operation, forward: NextLink) {
     let controller: AbortController;
+    
+    // override timeout from query context
+    var ctxTimeout = operation.getContext().timeout || null;
+    if(ctxTimeout <= 0) {
+      ctxTimeout = null;
+    }
 
     // add abort controller and signal object to fetchOptions if they don't already exist
     if (typeof AbortController !== 'undefined') {
@@ -64,7 +70,7 @@ export default class TimeoutLink extends ApolloLink {
 
         observer.error(new Error('Timeout exceeded'));
         subscription.unsubscribe();
-      }, this.timeout);
+      }, ctxTimeout || this.timeout);
 
       // this function is called when a client unsubscribes from localObservable
       return () => {


### PR DESCRIPTION
fixes #7 

Users will be able to use:

```
<Query
 query={SOME_QUERY}
 variables={{
    someVar1: "foo",
    someVar2: "bar",
   }}
  context={{ timeout: 3000 }}
>
```