### PR TITLE
Add timeoutRef to context

### DIFF
--- a/src/timeoutLink.ts
+++ b/src/timeoutLink.ts
@@ -72,6 +72,17 @@ export default class TimeoutLink extends ApolloLink {
         observer.error(new Error('Timeout exceeded'));
         subscription.unsubscribe();
       }, ctxTimeout || this.timeout);
+      
+      let ctxRef = operation.getContext().timeoutRef
+
+      if (ctxRef) {
+        ctxRef({
+          unsubscribe: () => {
+            clearTimeout(timer)
+            subscription.unsubscribe()
+          }
+        })
+      }
 
       // this function is called when a client unsubscribes from localObservable
       return () => {

--- a/src/timeoutLink.ts
+++ b/src/timeoutLink.ts
@@ -81,7 +81,7 @@ export default class TimeoutLink extends ApolloLink {
             clearTimeout(timer);
             subscription.unsubscribe();
           }
-        })
+        });
       }
 
       // this function is called when a client unsubscribes from localObservable

--- a/src/timeoutLink.ts
+++ b/src/timeoutLink.ts
@@ -73,13 +73,13 @@ export default class TimeoutLink extends ApolloLink {
         subscription.unsubscribe();
       }, ctxTimeout || this.timeout);
       
-      let ctxRef = operation.getContext().timeoutRef
+      let ctxRef = operation.getContext().timeoutRef;
 
       if (ctxRef) {
         ctxRef({
           unsubscribe: () => {
-            clearTimeout(timer)
-            subscription.unsubscribe()
+            clearTimeout(timer);
+            subscription.unsubscribe();
           }
         })
       }


### PR DESCRIPTION
Add a timeoutRef to the context to control the imperative cancellation or un-subscription of the subscriber. When creating a search box, it is desired that unsubscription to the graphql api is called everytime a user presses a keystroke nullyfying the former query so a new one can be ran.

With the timeoutRef, this is achievable since the ref exposes the unsubscription method to be used by the component to carry out this effect