### PR TITLE
feat: Import @apollo/client/core for non react users

### DIFF
--- a/__tests__/timeoutLink.test.ts
+++ b/__tests__/timeoutLink.test.ts
@@ -1,5 +1,5 @@
 import TimeoutLink from '../src/timeoutLink';
-import { ApolloLink, execute, Observable } from '@apollo/client';
+import { ApolloLink, execute, Observable } from '@apollo/client/core';
 import gql from 'graphql-tag';
 
 const TEST_TIMEOUT = 100;

--- a/src/timeoutLink.ts
+++ b/src/timeoutLink.ts
@@ -1,4 +1,4 @@
-import { ApolloLink, Observable, Operation, NextLink } from '@apollo/client';
+import { ApolloLink, Observable, Operation, NextLink } from '@apollo/client/core';
 import { DefinitionNode } from 'graphql';
 import TimeoutError from './TimeoutError';
 


### PR DESCRIPTION
closes #35 

Import apollo components from `@apollo/client/core` as `@apollo/client` is React specific 

Tested to work with VueJS **ONLY**

[From the docs:](https://apollo-angular.com/docs/migration/)
> The @apollo/client includes React-specific code so it's very important to use @apollo/client/core instead.
> The @apollo/client includes React-specific code so it's very very important to use @apollo/client/core instead.
> The @apollo/client includes React-specific code so it's very very very important to use @apollo/client/core instead.