### PR TITLE
Don't trigger timeout error when signal aborted elsewhere

### DIFF
--- a/__tests__/timeoutLink.test.ts
+++ b/__tests__/timeoutLink.test.ts
@@ -96,3 +96,23 @@ test('configured short value through context time out', done => {
     }
   });
 });
+
+test('aborted request does not timeout', done => {
+  delay = 200;
+
+  const controller = new AbortController();
+  const fetchOptions = { controller, signal: controller.signal }
+
+  controller.abort();
+
+  execute(link, { query, context: { fetchOptions } }).subscribe({
+    next() {
+      expect(called).toBe(1);
+      done();
+    },
+    error() {
+      expect('error called').toBeFalsy();
+      done();
+    }
+  });
+});

--- a/src/timeoutLink.ts
+++ b/src/timeoutLink.ts
@@ -95,14 +95,16 @@ export default class TimeoutLink extends ApolloLink {
         subscription.unsubscribe();
       };
 
-      // cancel timeout if aborted from somewhere else
-      controller.signal.addEventListener("abort", () => {
-        cancelTimeout();
-      });
-
       let ctxRef = operation.getContext().timeoutRef;
       if (ctxRef) {
         ctxRef({ unsubscribe: cancelTimeout });
+      }
+
+      if (controller) {
+        // cancel timeout if aborted from somewhere else
+        controller.signal.addEventListener("abort", () => {
+          cancelTimeout();
+        });
       }
 
       // this function is called when a client unsubscribes from localObservable

--- a/src/timeoutLink.ts
+++ b/src/timeoutLink.ts
@@ -19,6 +19,7 @@ export default class TimeoutLink extends ApolloLink {
 
   public request(operation: Operation, forward: NextLink) {
     let controller: AbortController;
+    let ourController: AbortController;
 
     // override timeout from query context
     const requestTimeout = operation.getContext().timeout || this.timeout;
@@ -28,7 +29,8 @@ export default class TimeoutLink extends ApolloLink {
       const context = operation.getContext();
       let fetchOptions = context.fetchOptions || {};
 
-      controller = fetchOptions.controller || new AbortController();
+      ourController = new AbortController();
+      controller = fetchOptions.controller || ourController;
 
       fetchOptions = { ...fetchOptions, controller, signal: controller.signal };
       operation.setContext({ fetchOptions });
@@ -66,6 +68,11 @@ export default class TimeoutLink extends ApolloLink {
       // if timeout expires before observable completes, abort call, unsubscribe, and return error
       timer = setTimeout(() => {
         if (controller) {
+          if (controller.signal.aborted) {
+            // already aborted from somewhere else
+            return;
+          }
+
           controller.abort(); // abort fetch operation
 
           // if the AbortController in the operation context is one we created,
@@ -73,8 +80,8 @@ export default class TimeoutLink extends ApolloLink {
           // future retry of the operation.
           const context = operation.getContext();
           let fetchOptions = context.fetchOptions || {};
-          if(fetchOptions.controller === controller && fetchOptions.signal === controller.signal) {
-             fetchOptions = { ...fetchOptions, controller: null, signal: null };
+          if(fetchOptions.controller === ourController && fetchOptions.signal === ourController.signal) {
+             fetchOptions = { ...fetchOptions, controller: undefined, signal: undefined };
              operation.setContext({ fetchOptions });
           }
         }
@@ -83,22 +90,23 @@ export default class TimeoutLink extends ApolloLink {
         subscription.unsubscribe();
       }, requestTimeout);
 
-      let ctxRef = operation.getContext().timeoutRef;
-
-      if (ctxRef) {
-        ctxRef({
-          unsubscribe: () => {
-            clearTimeout(timer);
-            subscription.unsubscribe();
-          }
-        });
-      }
-
-      // this function is called when a client unsubscribes from localObservable
-      return () => {
+      const cancelTimeout = () => {
         clearTimeout(timer);
         subscription.unsubscribe();
       };
+
+      // cancel timeout if aborted from somewhere else
+      controller.signal.addEventListener("abort", () => {
+        cancelTimeout();
+      });
+
+      let ctxRef = operation.getContext().timeoutRef;
+      if (ctxRef) {
+        ctxRef({ unsubscribe: cancelTimeout });
+      }
+
+      // this function is called when a client unsubscribes from localObservable
+      return cancelTimeout;
     });
 
     return localObservable;

--- a/src/timeoutLink.ts
+++ b/src/timeoutLink.ts
@@ -79,10 +79,9 @@ export default class TimeoutLink extends ApolloLink {
           // it's now "used up", so we need to remove it to avoid blocking any
           // future retry of the operation.
           const context = operation.getContext();
-          let fetchOptions = context.fetchOptions || {};
+          const fetchOptions = context.fetchOptions || {};
           if(fetchOptions.controller === ourController && fetchOptions.signal === ourController.signal) {
-             fetchOptions = { ...fetchOptions, controller: undefined, signal: undefined };
-             operation.setContext({ fetchOptions });
+             operation.setContext({ ...fetchOptions, controller: undefined, signal: undefined });
           }
         }
 
@@ -95,17 +94,15 @@ export default class TimeoutLink extends ApolloLink {
         subscription.unsubscribe();
       };
 
-      let ctxRef = operation.getContext().timeoutRef;
+      const ctxRef = operation.getContext().timeoutRef;
       if (ctxRef) {
         ctxRef({ unsubscribe: cancelTimeout });
       }
 
-      if (controller) {
-        // cancel timeout if aborted from somewhere else
-        controller.signal.addEventListener("abort", () => {
-          cancelTimeout();
-        });
-      }
+      // cancel timeout if aborted from somewhere else
+      controller.signal.addEventListener("abort", () => {
+        cancelTimeout();
+      }, { once: true });
 
       // this function is called when a client unsubscribes from localObservable
       return cancelTimeout;


### PR DESCRIPTION
Currently it's not really possible to use your own signal and abort outside of the TimeoutLink, because the timeout error is still triggered even if the request was aborted outside of the TimeoutLink.

This change lets you use your own signal properly by simply ensuring that an aborted signal unsubscribes from the timeout. In addition, we only clear out any existing signal when it's one that the TimeoutLink added, so that externally provided signals aren't cleared (might use a getter for example, to continue returning a valid signal).

Also added tests for this. Confirmed working for us in our application.