### PR TITLE
Include src in npm dist for sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   "author": "Dustin Callaway <drcallaway@gmail.com>",
   "license": "MIT",
   "files": [
-    "lib"
+    "lib",
+    "src"
   ],
   "jest": {
     "transform": {


### PR DESCRIPTION
Closes #62 

The sourcemaps were pointing at the `src` files, but since they were not included in the npm bundle, it was causing the sourcemaps to error. Now that the src code is included, the sourcemaps should work.