### PR TITLE
Add GH CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x, 20.x, 22.x, 23.x]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: yarn --ignore-scripts
+
+      - run: yarn lint
+
+      - run: yarn build
+
+      - run: yarn test


### PR DESCRIPTION
PR adds a GH workflow that'll run for new pushes to `master` and for incoming PRs to `master`, to help give confidence that a given change doesn't break things without necessarily needing to run the commands locally. I set up the workflow to test against all Node LTS releases for 12+ as I don't think `@apollo/client` has a specified version they support for node :shrug:

I used `--ignore-scripts` for the `yarn install` line so as to bypass the `prepublish` command in `package.json` which triggers the lint/build/test process, as I wanted them to be separate steps here to better identify what command failed when the workflow fails.