### PR TITLE
Fix type warnings for test file

### DIFF
--- a/__tests__/timeoutLink.test.ts
+++ b/__tests__/timeoutLink.test.ts
@@ -13,9 +13,10 @@ const query = gql`
   }
 }`;
 
-let called, delay;
+let called: number;
+let delay: number;
 
-const mockLink = new ApolloLink(operation => {
+const mockLink = new ApolloLink(() => {
   called++;
   return new Observable(observer => {
     setTimeout(() => {
@@ -72,7 +73,7 @@ test('configured value through context does not time out', done => {
       expect(called).toBe(1);
       done();
     },
-    error(error) {
+    error() {
       expect('error called').toBeFalsy();
       done();
     }


### PR DESCRIPTION
PR fixes two type warnings in the test file about a type not being declared, and so the variables were defaulting to `any`.