### PR TITLE
fix default typing for timeout param

### DIFF
--- a/src/timeoutLink.ts
+++ b/src/timeoutLink.ts
@@ -12,7 +12,14 @@ export default class TimeoutLink extends ApolloLink {
   private timeout: number;
   private statusCode?: number;
 
-  constructor(timeout: number, statusCode?: number) {
+  /**
+   * Creates a new TimeoutLink instance.
+   * Aborts the request if the timeout expires before the response is received.
+   *
+   * @param timeout - The timeout in milliseconds for the request. Default is 15000ms (15 seconds).
+   * @param statusCode - The HTTP status code to return when a timeout occurs. Default is 408 (Request Timeout).
+   */
+  constructor(timeout?: number, statusCode?: number) {
     super();
     this.timeout = timeout || DEFAULT_TIMEOUT;
     this.statusCode = statusCode;


### PR DESCRIPTION
PR fixes a bug in the typing for `TimeoutLink` where it mandated that `timeout` be passed into the constructor, even though there was logic to handle setting a default value if omitted.

As part of this, I've also updated the documentation for the constructor to indicate what the default values for `timeout` and `statusCode` will be if omitted.