### PR TITLE
fix return type on TimeoutLink#request

### DIFF
--- a/src/timeoutLink.ts
+++ b/src/timeoutLink.ts
@@ -56,7 +56,7 @@ export default class TimeoutLink extends ApolloLink {
 
     // create local observable with timeout functionality (unsubscibe from chain observable and
     // return an error if the timeout expires before chain observable resolves)
-    const localObservable = new Observable(observer => {
+    const localObservable = new Observable<FetchResult>(observer => {
       let timer: any;
 
       // listen to chainObservable for result and pass to localObservable if received before timeout


### PR DESCRIPTION
Our Angular Build encountered the following error with the version 5.0.2:

```shell
✘ [ERROR] TS2322: Type 'TimeoutLink' is not assignable to type 'ApolloLink | RequestHandler'.
  Type 'TimeoutLink' is not assignable to type 'ApolloLink'.
    The types returned by 'request(...)' are incompatible between these types.
      Type 'Observable<unknown>' is not assignable to type 'Observable<FetchResult>'.
        Type 'unknown' is not assignable to type 'FetchResult'. [plugin angular-compiler]
```
